### PR TITLE
Use url.URL and related instead of strings

### DIFF
--- a/aggregated_feed_test.go
+++ b/aggregated_feed_test.go
@@ -25,7 +25,7 @@ func TestAggregatedFeedGetActivities(t *testing.T) {
 		},
 		{
 			opts: []stream.GetActivitiesOption{stream.WithActivitiesLimit(42), stream.WithActivitiesOffset(11), stream.WithActivitiesIDGT("aabbcc")},
-			url:  "https://api.stream-io-api.com/api/v1.0/feed/aggregated/123/?api_key=key&limit=42&offset=11&id_gt=aabbcc",
+			url:  "https://api.stream-io-api.com/api/v1.0/feed/aggregated/123/?api_key=key&id_gt=aabbcc&limit=42&offset=11",
 		},
 	}
 

--- a/client.go
+++ b/client.go
@@ -302,7 +302,7 @@ func (c *Client) removeActivityByID(feed Feed, activityID string) error {
 
 func (c *Client) removeActivityByForeignID(feed Feed, foreignID string) error {
 	endpoint := c.makeEndpoint("feed/%s/%s/%s/", feed.Slug(), feed.UserID(), foreignID)
-	endpoint.query.Set("foreign_id", "1")
+	endpoint.addQueryParam(makeRequestOption("foreign_id", 1))
 	_, err := c.delete(endpoint, nil, c.authenticator.feedAuth(resFeed, feed))
 	return err
 }

--- a/client_internal_test.go
+++ b/client_internal_test.go
@@ -70,20 +70,20 @@ func Test_makeEndpoint(t *testing.T) {
 			url:      &apiURL{},
 			format:   "test-%d-%s",
 			args:     []interface{}{42, "asd"},
-			expected: "https://api.stream-io-api.com/api/v1.0/test-42-asd/?api_key=test",
+			expected: "https://api.stream-io-api.com/api/v1.0/test-42-asd?api_key=test",
 		},
 		{
 			url:      &apiURL{},
 			env:      "http://localhost:8000/api/v1.0/",
 			format:   "test-%d-%s",
 			args:     []interface{}{42, "asd"},
-			expected: "http://localhost:8000/api/v1.0/test-42-asd/?api_key=test",
+			expected: "http://localhost:8000/api/v1.0/test-42-asd?api_key=test",
 		},
 	}
 
 	for _, tc := range testCases {
 		os.Setenv("STREAM_URL", tc.env)
 		c := &Client{url: tc.url, key: "test"}
-		assert.Equal(t, tc.expected, c.makeEndpoint(tc.format, tc.args...))
+		assert.Equal(t, tc.expected, c.makeEndpoint(tc.format, tc.args...).String())
 	}
 }

--- a/flat_feed_test.go
+++ b/flat_feed_test.go
@@ -32,13 +32,13 @@ func TestFlatFeedGetActivities(t *testing.T) {
 				stream.WithActivitiesIDLT("ffgghh"),
 				stream.WithActivitiesIDLTE("iijjkk"),
 			},
-			url: "https://api.stream-io-api.com/api/v1.0/feed/flat/123/?api_key=key&limit=42&offset=11&id_gt=aabbcc&id_gte=ccddee&id_lt=ffgghh&id_lte=iijjkk",
+			url: "https://api.stream-io-api.com/api/v1.0/feed/flat/123/?api_key=key&id_gt=aabbcc&id_gte=ccddee&id_lt=ffgghh&id_lte=iijjkk&limit=42&offset=11",
 		},
 		{
 			opts: []stream.GetActivitiesOption{
 				stream.WithCustomParam("aaa", "bbb"),
 			},
-			url: "https://api.stream-io-api.com/api/v1.0/feed/flat/123/?api_key=key&aaa=bbb",
+			url: "https://api.stream-io-api.com/api/v1.0/feed/flat/123/?aaa=bbb&api_key=key",
 		},
 	}
 

--- a/notification_feed_test.go
+++ b/notification_feed_test.go
@@ -24,7 +24,7 @@ func TestGetNotificationActivities(t *testing.T) {
 		},
 		{
 			opts: []stream.GetActivitiesOption{stream.WithActivitiesLimit(42), stream.WithActivitiesOffset(11), stream.WithActivitiesIDGT("aabbcc")},
-			url:  "https://api.stream-io-api.com/api/v1.0/feed/notification/123/?api_key=key&limit=42&offset=11&id_gt=aabbcc",
+			url:  "https://api.stream-io-api.com/api/v1.0/feed/notification/123/?api_key=key&id_gt=aabbcc&limit=42&offset=11",
 		},
 		{
 			opts: []stream.GetActivitiesOption{stream.WithNotificationsMarkRead(false, "f1", "f2", "f3")},

--- a/options.go
+++ b/options.go
@@ -2,7 +2,6 @@ package stream
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 )
 
@@ -10,10 +9,15 @@ const (
 	defaultActivityCopyLimit = 300
 )
 
-// RequestOption is an interface representing API request optional filters and
+// requestOption is an interface representing API request optional filters and
 // parameters.
 type requestOption interface {
-	String() string
+	valuer
+}
+
+type valuer interface {
+	values() (string, string)
+	valid() bool
 }
 
 type baseRequestOption struct {
@@ -25,9 +29,12 @@ func makeRequestOption(key string, value interface{}) requestOption {
 	return baseRequestOption{key: key, value: value}
 }
 
-func (o baseRequestOption) String() string {
-	val := url.QueryEscape(fmt.Sprintf("%v", o.value))
-	return fmt.Sprintf("&%s=%s", o.key, val)
+func (o baseRequestOption) values() (string, string) {
+	return o.key, fmt.Sprintf("%v", o.value)
+}
+
+func (o baseRequestOption) valid() bool {
+	return true
 }
 
 func withLimit(limit int) requestOption {
@@ -217,6 +224,10 @@ func WithToTargetsRemove(targets ...string) UpdateToTargetsOption {
 
 type nop struct{}
 
-func (nop) String() string {
-	return ""
+func (nop) values() (string, string) {
+	return "", ""
+}
+
+func (nop) valid() bool {
+	return false
 }


### PR DESCRIPTION
Instead of using strings and concatenation/manipulation for URLs, queries, etc., just rely on the `net/url` package and its types.