### PR TITLE
Add GetNextPageActivities to Feed implementations

### DIFF
--- a/aggregated_feed.go
+++ b/aggregated_feed.go
@@ -23,3 +23,13 @@ func (f *AggregatedFeed) GetActivities(opts ...GetActivitiesOption) (*Aggregated
 	}
 	return &resp, nil
 }
+
+// GetNextPageActivities returns the activities for the given AggregatedFeed at the "next" page
+// of a previous *AggregatedFeedResponse response, if any.
+func (f *AggregatedFeed) GetNextPageActivities(resp *AggregatedFeedResponse) (*AggregatedFeedResponse, error) {
+	opts, err := resp.parseNext()
+	if err != nil {
+		return nil, err
+	}
+	return f.GetActivities(opts...)
+}

--- a/aggregated_feed_test.go
+++ b/aggregated_feed_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/GetStream/stream-go2"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAggregatedFeedGetActivities(t *testing.T) {
@@ -34,4 +35,15 @@ func TestAggregatedFeedGetActivities(t *testing.T) {
 		testRequest(t, requester.req, http.MethodGet, tc.url, "")
 		assert.NoError(t, err)
 	}
+}
+
+func TestAggregatedFeedGetNextPageActivities(t *testing.T) {
+	client, requester := newClient(t)
+	aggregated := newAggregatedFeedWithUserID(client, "123")
+	requester.resp = `{"next":"/api/v1.0/feed/aggregated/123/?id_lt=78c1a709-aff2-11e7-b3a7-a45e60be7d3b&limit=25"}`
+	resp, err := aggregated.GetActivities()
+	require.NoError(t, err)
+	_, err = aggregated.GetNextPageActivities(resp)
+	testRequest(t, requester.req, http.MethodGet, "https://api.stream-io-api.com/api/v1.0/feed/aggregated/123/?api_key=key&id_lt=78c1a709-aff2-11e7-b3a7-a45e60be7d3b&limit=25", "")
+	require.NoError(t, err)
 }

--- a/flat_feed.go
+++ b/flat_feed.go
@@ -21,10 +21,20 @@ func (f *FlatFeed) GetActivities(opts ...GetActivitiesOption) (*FlatFeedResponse
 	return &resp, nil
 }
 
+// GetNextPageActivities returns the activities for the given FlatFeed at the "next" page
+// of a previous *FlatFeedResponse response, if any.
+func (f *FlatFeed) GetNextPageActivities(resp *FlatFeedResponse) (*FlatFeedResponse, error) {
+	opts, err := resp.parseNext()
+	if err != nil {
+		return nil, err
+	}
+	return f.GetActivities(opts...)
+}
+
 // GetActivitiesWithRanking returns the activities (filtered) for the given FlatFeed,
 // using the provided ranking method.
 func (f *FlatFeed) GetActivitiesWithRanking(ranking string, opts ...GetActivitiesOption) (*FlatFeedResponse, error) {
-	return f.GetActivities(append(opts, getActivitiesWithRanking(ranking))...)
+	return f.GetActivities(append(opts, withActivitiesRanking(ranking))...)
 }
 
 // GetFollowers returns the feeds following the given FlatFeed.

--- a/flat_feed_test.go
+++ b/flat_feed_test.go
@@ -7,6 +7,7 @@ import (
 
 	stream "github.com/GetStream/stream-go2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFlatFeedGetActivities(t *testing.T) {
@@ -51,4 +52,15 @@ func TestFlatFeedGetActivities(t *testing.T) {
 		testRequest(t, requester.req, http.MethodGet, fmt.Sprintf("%s&ranking=popularity", tc.url), "")
 		assert.NoError(t, err)
 	}
+}
+
+func TestFlatFeedGetNextPageActivities(t *testing.T) {
+	client, requester := newClient(t)
+	flat := newFlatFeedWithUserID(client, "123")
+	requester.resp = `{"next":"/api/v1.0/feed/flat/123/?id_lt=78c1a709-aff2-11e7-b3a7-a45e60be7d3b&limit=25"}`
+	resp, err := flat.GetActivities()
+	require.NoError(t, err)
+	_, err = flat.GetNextPageActivities(resp)
+	testRequest(t, requester.req, http.MethodGet, "https://api.stream-io-api.com/api/v1.0/feed/flat/123/?api_key=key&id_lt=78c1a709-aff2-11e7-b3a7-a45e60be7d3b&limit=25", "")
+	require.NoError(t, err)
 }

--- a/notification_feed.go
+++ b/notification_feed.go
@@ -20,3 +20,13 @@ func (f *NotificationFeed) GetActivities(opts ...GetActivitiesOption) (*Notifica
 	}
 	return &resp, nil
 }
+
+// GetNextPageActivities returns the activities for the given NotificationFeed at the "next" page
+// of a previous *NotificationFeedResponse response, if any.
+func (f *NotificationFeed) GetNextPageActivities(resp *NotificationFeedResponse) (*NotificationFeedResponse, error) {
+	opts, err := resp.parseNext()
+	if err != nil {
+		return nil, err
+	}
+	return f.GetActivities(opts...)
+}

--- a/notification_feed_test.go
+++ b/notification_feed_test.go
@@ -6,6 +6,7 @@ import (
 
 	stream "github.com/GetStream/stream-go2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetNotificationActivities(t *testing.T) {
@@ -49,4 +50,15 @@ func TestGetNotificationActivities(t *testing.T) {
 		testRequest(t, requester.req, http.MethodGet, tc.url, "")
 		assert.NoError(t, err)
 	}
+}
+
+func TestNotificationFeedGetNextPageActivities(t *testing.T) {
+	client, requester := newClient(t)
+	notification := newNotificationFeedWithUserID(client, "123")
+	requester.resp = `{"next":"/api/v1.0/feed/notification/123/?id_lt=78c1a709-aff2-11e7-b3a7-a45e60be7d3b&limit=25"}`
+	resp, err := notification.GetActivities()
+	require.NoError(t, err)
+	_, err = notification.GetNextPageActivities(resp)
+	testRequest(t, requester.req, http.MethodGet, "https://api.stream-io-api.com/api/v1.0/feed/notification/123/?api_key=key&id_lt=78c1a709-aff2-11e7-b3a7-a45e60be7d3b&limit=25", "")
+	require.NoError(t, err)
 }

--- a/options.go
+++ b/options.go
@@ -22,19 +22,22 @@ type valuer interface {
 
 type baseRequestOption struct {
 	key   string
-	value interface{}
+	value string
 }
 
 func makeRequestOption(key string, value interface{}) requestOption {
-	return baseRequestOption{key: key, value: value}
+	return baseRequestOption{
+		key:   key,
+		value: fmt.Sprintf("%v", value),
+	}
 }
 
 func (o baseRequestOption) values() (string, string) {
-	return o.key, fmt.Sprintf("%v", o.value)
+	return o.key, o.value
 }
 
 func (o baseRequestOption) valid() bool {
-	return true
+	return o.value != ""
 }
 
 func withLimit(limit int) requestOption {
@@ -94,7 +97,7 @@ func WithActivitiesIDLT(id string) GetActivitiesOption {
 	return GetActivitiesOption{makeRequestOption("id_lt", id)}
 }
 
-func getActivitiesWithRanking(ranking string) GetActivitiesOption {
+func withActivitiesRanking(ranking string) GetActivitiesOption {
 	return GetActivitiesOption{makeRequestOption("ranking", ranking)}
 }
 

--- a/utils.go
+++ b/utils.go
@@ -1,7 +1,9 @@
 package stream
 
 import (
+	"net/url"
 	"reflect"
+	"strconv"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -34,4 +36,16 @@ func decodeData(data map[string]interface{}, target interface{}) (*mapstructure.
 		return nil, err
 	}
 	return cfg.Metadata, nil
+}
+
+func parseIntValue(values url.Values, key string) (int, bool, error) {
+	v := values.Get(key)
+	if v == "" {
+		return 0, false, nil
+	}
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, false, err
+	}
+	return i, true, nil
 }


### PR DESCRIPTION
This PR adds a `GetNextPageActivities` to Flat, Aggregated, and Notification feeds types that allows to easily retrieve the next page in a paginated result directly from a `GetActivities` response.

Example:
```go
feed, err := client.FlatFeed("user", "123")
if err != nil { /* ... */ }
resp, err := feed.GetActivities()
if err != nil { /* ... */ }
nextResp, err := feed.GetNextPageActivities(resp)
if err != nil { /* ... */ }
```