### PR TITLE
add activity copy limit support in body for batch follow

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -40,3 +40,26 @@ func TestFollowMany(t *testing.T) {
 	body := `[{"source":"aggregated:0","target":"flat:123"},{"source":"aggregated:1","target":"flat:123"},{"source":"aggregated:2","target":"flat:123"}]`
 	testRequest(t, requester.req, http.MethodPost, "https://api.stream-io-api.com/api/v1.0/follow_many/?api_key=key", body)
 }
+
+func TestFollowManyActivityCopyLimit(t *testing.T) {
+	var (
+		client, requester = newClient(t)
+		relationships     = make([]stream.FollowRelationship, 3)
+		flat              = newFlatFeedWithUserID(client, "123")
+	)
+
+	for i := range relationships {
+		other := newAggregatedFeedWithUserID(client, strconv.Itoa(i))
+		relationships[i] = stream.NewFollowRelationship(other, flat, stream.WithFollowRelationshipActivityCopyLimit(i))
+	}
+
+	err := client.FollowMany(relationships)
+	require.NoError(t, err)
+	body := `[{"source":"aggregated:0","target":"flat:123","activity_copy_limit":0},{"source":"aggregated:1","target":"flat:123","activity_copy_limit":1},{"source":"aggregated:2","target":"flat:123","activity_copy_limit":2}]`
+	testRequest(t, requester.req, http.MethodPost, "https://api.stream-io-api.com/api/v1.0/follow_many/?api_key=key", body)
+
+	err = client.FollowMany(relationships, stream.WithFollowManyActivityCopyLimit(123))
+	require.NoError(t, err)
+	body = `[{"source":"aggregated:0","target":"flat:123","activity_copy_limit":0},{"source":"aggregated:1","target":"flat:123","activity_copy_limit":1},{"source":"aggregated:2","target":"flat:123","activity_copy_limit":2}]`
+	testRequest(t, requester.req, http.MethodPost, "https://api.stream-io-api.com/api/v1.0/follow_many/?activity_copy_limit=123&api_key=key", body)
+}

--- a/types.go
+++ b/types.go
@@ -190,16 +190,31 @@ type AddToManyRequest struct {
 // FollowRelationship represents a follow relationship between a source
 // ("follower") and a target ("following"), used for FollowMany requests.
 type FollowRelationship struct {
-	Source string `json:"source,omitempty"`
-	Target string `json:"target,omitempty"`
+	Source            string `json:"source,omitempty"`
+	Target            string `json:"target,omitempty"`
+	ActivityCopyLimit *int   `json:"activity_copy_limit,omitempty"`
 }
 
 // NewFollowRelationship is a helper for creating a FollowRelationship from the
 // source ("follower") and target ("following") feeds.
-func NewFollowRelationship(source, target Feed) FollowRelationship {
-	return FollowRelationship{
+func NewFollowRelationship(source, target Feed, opts ...FollowRelationshipOption) FollowRelationship {
+	r := FollowRelationship{
 		Source: source.ID(),
 		Target: target.ID(),
+	}
+	for _, opt := range opts {
+		opt(&r)
+	}
+	return r
+}
+
+// FollowRelationshipOption customizes a FollowRelationship.
+type FollowRelationshipOption func(r *FollowRelationship)
+
+// WithFollowRelationshipActivityCopyLimit sets the ActivityCopyLimit field for a given FollowRelationship.
+func WithFollowRelationshipActivityCopyLimit(activityCopyLimit int) FollowRelationshipOption {
+	return func(r *FollowRelationship) {
+		r.ActivityCopyLimit = &activityCopyLimit
 	}
 }
 


### PR DESCRIPTION
This adds the possibility to add an activity copy limit to a batch follow single request.