### PR TITLE
Regions overrides

### DIFF
--- a/url.go
+++ b/url.go
@@ -20,9 +20,19 @@ func (u *apiURL) makeVersion() string {
 	return "1.0"
 }
 
+// handy rewrites for regions
+var regionOverrides = map[string]string{
+	"us-east":   "us-east-api",
+	"eu-west":   "eu-west-api",
+	"singapore": "singapore-api",
+}
+
 func (u *apiURL) makeRegion() string {
 	if u.region != "" {
-		return fmt.Sprintf("%s-api", u.region)
+		if override, ok := regionOverrides[u.region]; ok {
+			return override
+		}
+		return u.region
 	}
 	return "api"
 }

--- a/url_internal_test.go
+++ b/url_internal_test.go
@@ -17,8 +17,16 @@ func Test_URLString(t *testing.T) {
 			expected: fmt.Sprintf("https://api.%s/api/v1.0/", domain),
 		},
 		{
-			url:      &apiURL{region: "eu-central", version: "2.0"},
-			expected: fmt.Sprintf("https://eu-central-api.%s/api/v2.0/", domain),
+			url:      &apiURL{region: "us-east", version: "2.0"},
+			expected: fmt.Sprintf("https://us-east-api.%s/api/v2.0/", domain),
+		},
+		{
+			url:      &apiURL{region: "eu-west", version: "2.0"},
+			expected: fmt.Sprintf("https://eu-west-api.%s/api/v2.0/", domain),
+		},
+		{
+			url:      &apiURL{region: "singapore", version: "2.0"},
+			expected: fmt.Sprintf("https://singapore-api.%s/api/v2.0/", domain),
 		},
 	}
 


### PR DESCRIPTION
Override regions with defaults for easier client initialization when using `WithAPIRegion`.