### PR TITLE
Allow following w/ zero activity copy limit

### DIFF
--- a/options.go
+++ b/options.go
@@ -177,7 +177,7 @@ func WithUnfollowKeepHistory(keepHistory bool) UnfollowOption {
 
 type followFeedOptions struct {
 	Target            string `json:"target,omitempty"`
-	ActivityCopyLimit int    `json:"activity_copy_limit,omitempty"`
+	ActivityCopyLimit int    `json:"activity_copy_limit"`
 }
 
 // FollowManyOption is an option to customize behavior of Follow Many calls.


### PR DESCRIPTION
When following feeds w/ zero activity copy limit client sends request to Stream servers w/ default activity copy limit of 100
This is due to `omitempty` json annotation.
I propose removal of this annotation as `ActivityCopyLimit` is always initialised to default value in the code before applying any user provided options.