### PR TITLE
Fix connection keepalive

### DIFF
--- a/client.go
+++ b/client.go
@@ -34,8 +34,10 @@ func NewClient(key, secret string, opts ...ClientOption) (*Client, error) {
 		return nil, errMissingCredentials
 	}
 	c := &Client{
-		key:           key,
-		requester:     &http.Client{},
+		key: key,
+		requester: &http.Client{
+			Transport: &http.Transport{},
+		},
 		authenticator: authenticator{secret: secret},
 	}
 	for _, opt := range opts {

--- a/client.go
+++ b/client.go
@@ -251,10 +251,13 @@ func (c *Client) request(method string, endpoint endpoint, data interface{}, aut
 	if resp.StatusCode/100 != 2 {
 		return nil, c.makeStreamError(resp.StatusCode, resp.Body)
 	}
+	defer resp.Body.Close()
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read response: %s", err)
 	}
+
 	return body, nil
 }
 


### PR DESCRIPTION
Set a default `http.Transport` for the requester client. Also, actually close the response body.