### PR TITLE
Support activities GET endpoint

### DIFF
--- a/authenticator.go
+++ b/authenticator.go
@@ -72,7 +72,13 @@ func (a authenticator) feedID(feed Feed) string {
 
 func (a authenticator) feedAuth(resource resource, feed Feed) authFunc {
 	return func(req *http.Request) error {
-		return a.jwtSignRequest(req, a.jwtFeedClaims(resource, actions[req.Method], a.feedID(feed)))
+		var feedID string
+		if feed != nil {
+			feedID = a.feedID(feed)
+		} else {
+			feedID = "*"
+		}
+		return a.jwtSignRequest(req, a.jwtFeedClaims(resource, actions[req.Method], feedID))
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 	"testing"
+	"time"
 
 	stream "github.com/GetStream/stream-go2"
 	"github.com/stretchr/testify/assert"
@@ -95,4 +96,16 @@ func TestUnfollowMany(t *testing.T) {
 	require.NoError(t, err)
 	body := `[{"source":"src:0","target":"tgt:0","keep_history":true},{"source":"src:1","target":"tgt:1","keep_history":false},{"source":"src:2","target":"tgt:2","keep_history":true}]`
 	testRequest(t, requester.req, http.MethodPost, "https://api.stream-io-api.com/api/v1.0/unfollow_many/?api_key=key", body)
+}
+
+func TestGetActivities(t *testing.T) {
+	client, requester := newClient(t)
+	_, err := client.GetActivitiesByID("foo", "bar", "baz")
+	require.NoError(t, err)
+	testRequest(t, requester.req, http.MethodGet, "https://api.stream-io-api.com/api/v1.0/activities/?api_key=key&ids=foo%2Cbar%2Cbaz", "")
+	_, err = client.GetActivitiesByForeignID(
+		stream.NewForeignIDTimePair("foo", stream.Time{}),
+		stream.NewForeignIDTimePair("bar", stream.Time{Time: time.Time{}.Add(time.Second)}),
+	)
+	testRequest(t, requester.req, http.MethodGet, "https://api.stream-io-api.com/api/v1.0/activities/?api_key=key&foreign_ids=foo%2Cbar&timestamps=0001-01-01T00%3A00%3A00%2C0001-01-01T00%3A00%3A01", "")
 }

--- a/types.go
+++ b/types.go
@@ -342,3 +342,24 @@ func (r *PersonalizationResponse) UnmarshalJSON(data []byte) error {
 	}
 	return nil
 }
+
+// GetActivitiesResponse contains a slice of Activity returned by GetActivitiesByID
+// and GetActivitiesByForeignID requests.
+type GetActivitiesResponse struct {
+	response
+	Results []Activity `json:"results"`
+}
+
+// ForeignIDTimePair couples an activity's foreignID and timestamp.
+type ForeignIDTimePair struct {
+	ForeignID string
+	Timestamp Time
+}
+
+// NewForeignIDTimePair creates a new ForeignIDTimePair with the given foreign ID and timestamp.
+func NewForeignIDTimePair(foreignID string, timestamp Time) ForeignIDTimePair {
+	return ForeignIDTimePair{
+		ForeignID: foreignID,
+		Timestamp: timestamp,
+	}
+}


### PR DESCRIPTION
Add support for the new `GET /activities/` endpoint which allows to retrieve an app's activities by ID or foreign ID and timestamp.