### PR TITLE
Move UpdateActivities to Client level

### DIFF
--- a/client.go
+++ b/client.go
@@ -195,6 +195,19 @@ func (c *Client) getAppActivities(values ...valuer) (*GetActivitiesResponse, err
 	return &resp, nil
 }
 
+// UpdateActivities updates existing activities.
+func (c *Client) UpdateActivities(activities ...Activity) error {
+	signedActivities := c.signActivities(activities)
+	req := struct {
+		Activities []Activity `json:"activities,omitempty"`
+	}{
+		Activities: signedActivities,
+	}
+	endpoint := c.makeEndpoint("activities/")
+	_, err := c.post(endpoint, req, c.authenticator.feedAuth(resActivities, nil))
+	return err
+}
+
 // UpdateActivityByID performs a partial activity update with the given set and unset operations, returning the
 // affected activity, on the activity with the given ID.
 func (c *Client) UpdateActivityByID(id string, set map[string]interface{}, unset []string) (*UpdateActivityResponse, error) {
@@ -393,18 +406,6 @@ func (c *Client) addActivities(feed Feed, activities ...Activity) (*AddActivitie
 		return nil, fmt.Errorf("cannot unmarshal response: %s", err)
 	}
 	return &out, nil
-}
-
-func (c *Client) updateActivities(activities ...Activity) error {
-	signedActivities := c.signActivities(activities)
-	req := struct {
-		Activities []Activity `json:"activities,omitempty"`
-	}{
-		Activities: signedActivities,
-	}
-	endpoint := c.makeEndpoint("activities/")
-	_, err := c.post(endpoint, req, c.authenticator.feedAuth(resActivities, nil))
-	return err
 }
 
 func (c *Client) removeActivityByID(feed Feed, activityID string) error {

--- a/feed.go
+++ b/feed.go
@@ -10,7 +10,6 @@ type Feed interface {
 	UserID() string
 	AddActivity(Activity) (*AddActivityResponse, error)
 	AddActivities(...Activity) (*AddActivitiesResponse, error)
-	UpdateActivities(...Activity) error
 	RemoveActivityByID(string) error
 	RemoveActivityByForeignID(string) error
 	Follow(*FlatFeed, ...FollowFeedOption) error
@@ -53,11 +52,6 @@ func (f *feed) AddActivity(activity Activity) (*AddActivityResponse, error) {
 // AddActivities adds multiple activities to the feed.
 func (f *feed) AddActivities(activities ...Activity) (*AddActivitiesResponse, error) {
 	return f.client.addActivities(f, activities...)
-}
-
-// UpdateActivities updates existing activities in the feed.
-func (f *feed) UpdateActivities(activities ...Activity) error {
-	return f.client.updateActivities(activities...)
 }
 
 // RemoveActivityByID removes an activity from the feed (if present), using the provided

--- a/feed_test.go
+++ b/feed_test.go
@@ -51,7 +51,6 @@ func TestAddActivities(t *testing.T) {
 func TestUpdateActivities(t *testing.T) {
 	var (
 		client, requester = newClient(t)
-		flat              = newFlatFeedWithUserID(client, "123")
 		now               = getTime(time.Now())
 		bobActivity       = stream.Activity{
 			Actor:     "bob",
@@ -62,7 +61,7 @@ func TestUpdateActivities(t *testing.T) {
 			Extra:     map[string]interface{}{"influence": 42},
 		}
 	)
-	err := flat.UpdateActivities(bobActivity)
+	err := client.UpdateActivities(bobActivity)
 	require.NoError(t, err)
 
 	body := fmt.Sprintf(`{"activities":[{"actor":"bob","foreign_id":"bob:123","influence":42,"object":"ice-cream","time":"%s","verb":"like"}]}`, now.Format(stream.TimeLayout))


### PR DESCRIPTION
The `UpdateActivities` in unrelated to a specific field, hence should be moved from the `Feed` interface to the `Client` type.