### PR TITLE
Add struct for enriched activity

### DIFF
--- a/enriched_activities.go
+++ b/enriched_activities.go
@@ -1,6 +1,101 @@
 package stream
 
-type EnrichedActivity map[string]interface{}
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/fatih/structs"
+)
+
+// EnrichedActivity is an enriched Stream activity entity.
+type EnrichedActivity struct {
+	ID              string                         `json:"id,omitempty"`
+	Actor           Data                           `json:"actor,omitempty"`
+	Verb            string                         `json:"verb,omitempty"`
+	Object          Data                           `json:"object,omitempty"`
+	ForeignID       string                         `json:"foreign_id,omitempty"`
+	Target          Data                           `json:"target,omitempty"`
+	Time            Time                           `json:"time,omitempty"`
+	Origin          Data                           `json:"origin,omitempty"`
+	To              []string                       `json:"to,omitempty"`
+	Score           float64                        `json:"score,omitempty"`
+	ReactionCounts  map[string]int                 `json:"reaction_counts,omitempty"`
+	OwnReactions    map[string][]*EnrichedReaction `json:"own_reactions,omitempty"`
+	LatestReactions map[string][]*EnrichedReaction `json:"latest_reactions,omitempty"`
+	Extra           map[string]interface{}         `json:"-"`
+}
+
+// EnrichedReaction is an enriched Stream reaction entity.
+type EnrichedReaction struct {
+	ID                string                         `json:"id,omitempty"`
+	Kind              string                         `json:"kind"`
+	ActivityID        string                         `json:"activity_id"`
+	UserID            string                         `json:"user_id"`
+	Data              map[string]interface{}         `json:"data,omitempty"`
+	TargetFeeds       []string                       `json:"target_feeds,omitempty"`
+	ParentID          string                         `json:"parent,omitempty"`
+	ChildrenReactions map[string][]*EnrichedReaction `json:"latest_children,omitempty"`
+	OwnChildren       map[string][]*EnrichedReaction `json:"own_children,omitempty"`
+	ChildrenCounters  map[string]int                 `json:"children_counts,omitempty"`
+	User              Data                           `json:"user,omitempty"`
+	CreatedAt         Time                           `json:"created_at,omitempty"`
+	UpdatedAt         Time                           `json:"updated_at,omitempty"`
+}
+
+// UnmarshalJSON decodes the provided JSON payload into the EnrichedActivity. It's required
+// because of the custom JSON fields and time formats.
+func (a *EnrichedActivity) UnmarshalJSON(b []byte) error {
+	var data map[string]interface{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+
+	if _, ok := data["to"]; ok {
+		tos := data["to"].([]interface{})
+		simpleTos := make([]string, len(tos))
+		for i := range tos {
+			if sliceTos, isString := tos[i].(string); isString {
+				simpleTos[i] = sliceTos
+			} else if sliceTos, isSlice := tos[i].([]interface{}); isSlice {
+				tos, ok := sliceTos[0].(string)
+				if !ok {
+					return fmt.Errorf("invalid format for to targets")
+				}
+				simpleTos[i] = tos
+			}
+		}
+		data["to"] = simpleTos
+	}
+
+	return a.decode(data)
+}
+
+// MarshalJSON encodes the EnrichedActivity to a valid JSON bytes slice. It's required because of
+// the custom JSON fields and time formats.
+func (a EnrichedActivity) MarshalJSON() ([]byte, error) {
+	data := structs.New(a).Map()
+	for k, v := range a.Extra {
+		data[k] = v
+	}
+	if _, ok := data["time"]; ok {
+		data["time"] = a.Time.Format(TimeLayout)
+	}
+	return json.Marshal(data)
+}
+
+func (a *EnrichedActivity) decode(data map[string]interface{}) error {
+	meta, err := decodeData(data, a)
+	if err != nil {
+		return err
+	}
+	if len(meta.Unused) > 0 {
+		a.Extra = make(map[string]interface{})
+		for _, k := range meta.Unused {
+			a.Extra[k] = data[k]
+		}
+	}
+	return nil
+}
 
 // EnrichedActivityGroup is a group of enriched Activities obtained from aggregated feeds.
 type EnrichedActivityGroup struct {

--- a/enriched_activities_test.go
+++ b/enriched_activities_test.go
@@ -1,0 +1,78 @@
+package stream_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/GetStream/stream-go2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnrichedActivityUnmarshalJSON(t *testing.T) {
+	now := getTime(time.Now())
+	testCases := []struct {
+		activity stream.EnrichedActivity
+		data     []byte
+	}{
+		{
+			activity: stream.EnrichedActivity{Actor: stream.Data{ID: "actor"}, Verb: "verb", Object: stream.Data{ID: "object"}},
+			data:     []byte(`{"actor":"actor","object":"object","verb":"verb"}`),
+		},
+		{
+			activity: stream.EnrichedActivity{Actor: stream.Data{ID: "actor"}, Verb: "verb", Object: stream.Data{ID: "object"}, Time: now},
+			data:     []byte(`{"actor":"actor","object":"object","time":"` + now.Format(stream.TimeLayout) + `","verb":"verb"}`),
+		},
+		{
+			activity: stream.EnrichedActivity{Actor: stream.Data{ID: "actor"}, Verb: "verb", Object: stream.Data{ID: "object"}, Time: now, Extra: map[string]interface{}{"popularity": 42.0, "size": map[string]interface{}{"width": 800.0, "height": 600.0}}},
+			data:     []byte(`{"actor":"actor","object":"object","popularity":42,"size":{"height":600,"width":800},"time":"` + now.Format(stream.TimeLayout) + `","verb":"verb"}`),
+		},
+		{
+			activity: stream.EnrichedActivity{Actor: stream.Data{ID: "actor"}, Verb: "verb", Object: stream.Data{ID: "object"}, Time: now, Extra: map[string]interface{}{"popularity": 42.0, "size": map[string]interface{}{"width": 800.0, "height": 600.0}}},
+			data:     []byte(`{"actor":"actor","object":"object","popularity":42,"size":{"height":600,"width":800},"time":"` + now.Format(stream.TimeLayout) + `","verb":"verb"}`),
+		},
+		{
+			activity: stream.EnrichedActivity{To: []string{"abcd", "efgh"}},
+			data:     []byte(`{"to":["abcd","efgh"]}`),
+		},
+	}
+	for _, tc := range testCases {
+		var out stream.EnrichedActivity
+		err := json.Unmarshal(tc.data, &out)
+		require.NoError(t, err)
+		assert.Equal(t, tc.activity, out)
+	}
+}
+
+func TestEnrichedActivityUnmarshalJSON_toTargets(t *testing.T) {
+	testCases := []struct {
+		activity    stream.EnrichedActivity
+		data        []byte
+		shouldError bool
+	}{
+		{
+			activity: stream.EnrichedActivity{To: []string{"abcd", "efgh"}},
+			data:     []byte(`{"to":["abcd","efgh"]}`),
+		},
+		{
+			activity: stream.EnrichedActivity{To: []string{"abcd", "efgh"}},
+			data:     []byte(`{"to":[["abcd", "foo"], ["efgh", "bar"]]}`),
+		},
+		{
+			activity:    stream.EnrichedActivity{To: []string{"abcd", "efgh"}},
+			data:        []byte(`{"to":[[123]]}`),
+			shouldError: true,
+		},
+	}
+	for _, tc := range testCases {
+		var out stream.EnrichedActivity
+		err := json.Unmarshal(tc.data, &out)
+		if tc.shouldError {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			assert.Equal(t, tc.activity, out)
+		}
+	}
+}

--- a/stream.go
+++ b/stream.go
@@ -7,10 +7,13 @@ import (
 const (
 	// TimeLayout is the default time parse layout for Stream API JSON time fields
 	TimeLayout = "2006-01-02T15:04:05.999999"
+	// ReactionTimeLayout is the time parse layout for Stream Reaction API JSON time fields
+	ReactionTimeLayout = "2006-01-02T15:04:05.999999Z07:00"
 )
 
 var timeLayouts = []string{
 	TimeLayout,
+	ReactionTimeLayout,
 	"2006-01-02 15:04:05.999999-07:00",
 }
 

--- a/utils.go
+++ b/utils.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-func decodeJSONStringTimes(f reflect.Type, typ reflect.Type, data interface{}) (interface{}, error) {
+func decodeJSONHook(f reflect.Type, typ reflect.Type, data interface{}) (interface{}, error) {
 	switch typ {
 	case reflect.TypeOf(Time{}):
 		return timeFromString(data.(string))
@@ -23,13 +23,28 @@ func decodeJSONStringTimes(f reflect.Type, typ reflect.Type, data interface{}) (
 		default:
 			return nil, fmt.Errorf("invalid duration")
 		}
+	case reflect.TypeOf(Data{}):
+		switch v := data.(type) {
+		case string:
+			return Data{
+				ID: v,
+			}, nil
+		case map[string]interface{}:
+			a := Data{}
+			if err := a.decode(v); err != nil {
+				return nil, err
+			}
+			return a, nil
+		default:
+			return nil, fmt.Errorf("invalid data")
+		}
 	}
 	return data, nil
 }
 
 func decodeData(data map[string]interface{}, target interface{}) (*mapstructure.Metadata, error) {
 	cfg := &mapstructure.DecoderConfig{
-		DecodeHook: decodeJSONStringTimes,
+		DecodeHook: decodeJSONHook,
 		Result:     target,
 		Metadata:   &mapstructure.Metadata{},
 		TagName:    "json",

--- a/utils_internal_test.go
+++ b/utils_internal_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_decodeJSONStringTimes(t *testing.T) {
+func Test_decodeJSONHook(t *testing.T) {
 	now, _ := time.Parse(TimeLayout, "2006-01-02T15:04:05.999999")
 	testCases := []struct {
 		f           reflect.Type
@@ -61,9 +61,32 @@ func Test_decodeJSONStringTimes(t *testing.T) {
 			data:        struct{}{},
 			shouldError: true,
 		},
+		{
+			f:           reflect.TypeOf(string("")),
+			typ:         reflect.TypeOf(Data{}),
+			data:        "test",
+			shouldError: false,
+			expected:    Data{ID: "test"},
+		},
+		{
+			f:   reflect.TypeOf(map[string]interface{}{}),
+			typ: reflect.TypeOf(Data{}),
+			data: map[string]interface{}{
+				"id":    "test",
+				"extra": "data",
+			},
+			shouldError: false,
+			expected:    Data{ID: "test", Extra: map[string]interface{}{"extra": "data"}},
+		},
+		{
+			f:           reflect.TypeOf(float64(0)),
+			typ:         reflect.TypeOf(Data{}),
+			data:        struct{}{},
+			shouldError: true,
+		},
 	}
 	for _, tc := range testCases {
-		out, err := decodeJSONStringTimes(tc.f, tc.typ, tc.data)
+		out, err := decodeJSONHook(tc.f, tc.typ, tc.data)
 		if tc.shouldError {
 			require.Error(t, err)
 		} else {


### PR DESCRIPTION
This adds a struct for the enriched activity, similar to the `Activity` struct.

The fields were taken from https://github.com/GetStream/stream-java/blob/47add14b35951b17ce5aa45716f1e66eba69788e/src/main/java/io/getstream/core/models/EnrichedActivity.java and based on my own testing.

I also added an `EnrichedReaction` struct since it includes more fields than the `Reaction`. I tested on my own app and it seems that `created_at` and `updated_at` use a different time format than the other fields in the API; they also seem to include the timezone (only `Z` though).

I'm not sure if `MarshalJSON` is required for `EnrichedActivity` since it will never be serialized, but this is simply a copy from `Activity`.