### PR TITLE
Compile user id regex once instead of per request

### DIFF
--- a/feed.go
+++ b/feed.go
@@ -22,6 +22,14 @@ type Feed interface {
 	RealtimeToken(bool) string
 }
 
+var (
+	userIDRegex *regexp.Regexp
+)
+
+func init() {
+	userIDRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+}
+
 type feed struct {
 	slug   string
 	userID string
@@ -44,7 +52,6 @@ func (f *feed) UserID() string {
 }
 
 func newFeed(slug, userID string, client *Client) (*feed, error) {
-	userIDRegex := regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 	ok := userIDRegex.Match([]byte(userID))
 	if !ok {
 		return nil, errInvalidUserID


### PR DESCRIPTION
Was reading through source code and noticed each call to `newFeed` would compile regex, it also wouldn't catch an invalid regex unless `newFeed` was called.

This change makes it so that the regex is compiled once globally, and will panic if the regex is invalid on import, rather than when `newFeed` is called.