### PR TITLE
Use errors.New when not formatting and use %w directive when wrapping errors

### DIFF
--- a/activity.go
+++ b/activity.go
@@ -2,7 +2,7 @@ package stream
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 
 	"github.com/fatih/structs"
 )
@@ -40,7 +40,7 @@ func (a *Activity) UnmarshalJSON(b []byte) error {
 			case []interface{}:
 				tos, ok := to[0].(string)
 				if !ok {
-					return fmt.Errorf("invalid format for to targets")
+					return errors.New("invalid format for to targets")
 				}
 				simpleTos[i] = tos
 			}

--- a/authenticator.go
+++ b/authenticator.go
@@ -143,7 +143,7 @@ func (a authenticator) jwtFeedClaims(resource resource, action action, feedID st
 func (a authenticator) jwtSignRequest(req *http.Request, claims jwt.MapClaims) error {
 	auth, err := a.jwtSignatureFromClaims(claims)
 	if err != nil {
-		return fmt.Errorf("cannot make auth: %s", err)
+		return fmt.Errorf("cannot make auth: %w", err)
 	}
 	req.Header.Add("Stream-Auth-Type", "jwt")
 	req.Header.Add("Authorization", auth)

--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -299,7 +300,7 @@ func (c *Client) updateActivity(req UpdateActivityRequest) (*UpdateActivityRespo
 
 func (c *Client) makeStreamError(statusCode int, body io.Reader) error {
 	if body == nil {
-		return fmt.Errorf("invalid body")
+		return errors.New("invalid body")
 	}
 	errBody, err := ioutil.ReadAll(body)
 	if err != nil {
@@ -371,14 +372,14 @@ func (c *Client) request(method string, endpoint endpoint, data interface{}, aut
 	if data != nil {
 		payload, err := json.Marshal(data)
 		if err != nil {
-			return nil, fmt.Errorf("cannot marshal request: %s", err)
+			return nil, fmt.Errorf("cannot marshal request: %w", err)
 		}
 		reader = bytes.NewReader(payload)
 	}
 
 	req, err := http.NewRequest(method, endpoint.String(), reader)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create request: %s", err)
+		return nil, fmt.Errorf("cannot create request: %w", err)
 	}
 	c.setBaseHeaders(req)
 
@@ -390,7 +391,7 @@ func (c *Client) request(method string, endpoint endpoint, data interface{}, aut
 
 	resp, err := c.requester.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("cannot perform request: %s", err)
+		return nil, fmt.Errorf("cannot perform request: %w", err)
 	}
 	if resp.StatusCode/100 != 2 {
 		return nil, c.makeStreamError(resp.StatusCode, resp.Body)
@@ -399,7 +400,7 @@ func (c *Client) request(method string, endpoint endpoint, data interface{}, aut
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("cannot read response: %s", err)
+		return nil, fmt.Errorf("cannot read response: %w", err)
 	}
 
 	return body, nil
@@ -435,7 +436,7 @@ func (c *Client) addActivities(feed Feed, activities ...Activity) (*AddActivitie
 	}
 	var out AddActivitiesResponse
 	if err := json.Unmarshal(resp, &out); err != nil {
-		return nil, fmt.Errorf("cannot unmarshal response: %s", err)
+		return nil, fmt.Errorf("cannot unmarshal response: %w", err)
 	}
 	return &out, nil
 }

--- a/collections.go
+++ b/collections.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -14,7 +15,7 @@ type CollectionsClient struct {
 // Upsert creates new or updates existing objects for the given collection's name.
 func (c *CollectionsClient) Upsert(collection string, objects ...CollectionObject) error {
 	if collection == "" {
-		return fmt.Errorf("collection name required")
+		return errors.New("collection name required")
 	}
 	endpoint := c.client.makeEndpoint("collections/")
 	data := map[string]interface{}{
@@ -30,7 +31,7 @@ func (c *CollectionsClient) Upsert(collection string, objects ...CollectionObjec
 // having the given IDs.
 func (c *CollectionsClient) Select(collection string, ids ...string) ([]GetCollectionResponseObject, error) {
 	if collection == "" {
-		return nil, fmt.Errorf("collection name required")
+		return nil, errors.New("collection name required")
 	}
 	foreignIDs := make([]string, len(ids))
 	for i := range ids {
@@ -53,7 +54,7 @@ func (c *CollectionsClient) Select(collection string, ids ...string) ([]GetColle
 // DeleteMany removes from a collection the objects having the given IDs.
 func (c *CollectionsClient) DeleteMany(collection string, ids ...string) error {
 	if collection == "" {
-		return fmt.Errorf("collection name required")
+		return errors.New("collection name required")
 	}
 	endpoint := c.client.makeEndpoint("collections/")
 	endpoint.addQueryParam(makeRequestOption("collection_name", collection))
@@ -65,7 +66,7 @@ func (c *CollectionsClient) DeleteMany(collection string, ids ...string) error {
 // Add adds a single object to a collection.
 func (c *CollectionsClient) Add(collection string, object CollectionObject, opts ...AddObjectOption) (*CollectionObject, error) {
 	if collection == "" {
-		return nil, fmt.Errorf("collection name required")
+		return nil, errors.New("collection name required")
 	}
 	endpoint := c.client.makeEndpoint("collections/%s/", collection)
 
@@ -93,7 +94,7 @@ func (c *CollectionsClient) Add(collection string, object CollectionObject, opts
 // Get retrieves a collection object having the given ID.
 func (c *CollectionsClient) Get(collection, id string) (*CollectionObject, error) {
 	if collection == "" {
-		return nil, fmt.Errorf("collection name required")
+		return nil, errors.New("collection name required")
 	}
 	endpoint := c.client.makeEndpoint("collections/%s/%s/", collection, id)
 
@@ -112,7 +113,7 @@ func (c *CollectionsClient) Get(collection, id string) (*CollectionObject, error
 // Update updates the given collection object's data.
 func (c *CollectionsClient) Update(collection, id string, data map[string]interface{}) (*CollectionObject, error) {
 	if collection == "" {
-		return nil, fmt.Errorf("collection name required")
+		return nil, errors.New("collection name required")
 	}
 	endpoint := c.client.makeEndpoint("collections/%s/%s/", collection, id)
 	reqData := map[string]interface{}{
@@ -134,7 +135,7 @@ func (c *CollectionsClient) Update(collection, id string, data map[string]interf
 // Delete removes from a collection the object having the given ID.
 func (c *CollectionsClient) Delete(collection, id string) error {
 	if collection == "" {
-		return fmt.Errorf("collection name required")
+		return errors.New("collection name required")
 	}
 	endpoint := c.client.makeEndpoint("collections/%s/%s/", collection, id)
 

--- a/enriched_activities.go
+++ b/enriched_activities.go
@@ -2,7 +2,7 @@ package stream
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 
 	"github.com/fatih/structs"
 )
@@ -60,7 +60,7 @@ func (a *EnrichedActivity) UnmarshalJSON(b []byte) error {
 			case []interface{}:
 				tos, ok := to[0].(string)
 				if !ok {
-					return fmt.Errorf("invalid format for to targets")
+					return errors.New("invalid format for to targets")
 				}
 				simpleTos[i] = tos
 			}

--- a/errors.go
+++ b/errors.go
@@ -1,12 +1,12 @@
 package stream
 
 import (
-	"fmt"
+	"errors"
 )
 
 var (
-	errMissingCredentials = fmt.Errorf("missing API key or secret")
-	errInvalidUserID      = fmt.Errorf("invalid userID provided")
+	errMissingCredentials = errors.New("missing API key or secret")
+	errInvalidUserID      = errors.New("invalid userID provided")
 )
 
 // APIError is an error returned by Stream API when the request cannot be

--- a/personalization.go
+++ b/personalization.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -13,7 +14,7 @@ type PersonalizationClient struct {
 // Get obtains a PersonalizationResponse for the given resource and params.
 func (c *PersonalizationClient) Get(resource string, params map[string]interface{}) (*PersonalizationResponse, error) {
 	if resource == "" {
-		return nil, fmt.Errorf("missing resource")
+		return nil, errors.New("missing resource")
 	}
 	endpoint := c.client.makeEndpoint("%s/", resource)
 	for k, v := range params {
@@ -26,7 +27,7 @@ func (c *PersonalizationClient) Get(resource string, params map[string]interface
 	var personalizationResp PersonalizationResponse
 	err = json.Unmarshal(resp, &personalizationResp)
 	if err != nil {
-		return nil, fmt.Errorf("cannot unmarshal resp: %s", err)
+		return nil, fmt.Errorf("cannot unmarshal resp: %w", err)
 	}
 	return &personalizationResp, nil
 }
@@ -34,7 +35,7 @@ func (c *PersonalizationClient) Get(resource string, params map[string]interface
 // Post sends data to the given resource, adding the given params to the request.
 func (c *PersonalizationClient) Post(resource string, params, data map[string]interface{}) error {
 	if resource == "" {
-		return fmt.Errorf("missing resource")
+		return errors.New("missing resource")
 	}
 	endpoint := c.client.makeEndpoint("%s/", resource)
 	for k, v := range params {
@@ -52,7 +53,7 @@ func (c *PersonalizationClient) Post(resource string, params, data map[string]in
 // Delete removes data from the given resource, adding the given params to the request.
 func (c *PersonalizationClient) Delete(resource string, params map[string]interface{}) error {
 	if resource == "" {
-		return fmt.Errorf("missing resource")
+		return errors.New("missing resource")
 	}
 	endpoint := c.client.makeEndpoint("%s/", resource)
 	for k, v := range params {

--- a/types.go
+++ b/types.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -29,7 +30,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 	case float64:
 		*d, err = durationFromString(fmt.Sprintf("%fs", v))
 	default:
-		err = fmt.Errorf("invalid duration")
+		err = errors.New("invalid duration")
 	}
 	return err
 }
@@ -120,10 +121,10 @@ type readResponse struct {
 var (
 	// ErrMissingNextPage is returned when trying to read the next page of a response
 	// which has an empty "next" field.
-	ErrMissingNextPage = fmt.Errorf("request missing next page")
+	ErrMissingNextPage = errors.New("request missing next page")
 	// ErrInvalidNextPage is returned when trying to read the next page of a response
 	// which has an invalid "next" field.
-	ErrInvalidNextPage = fmt.Errorf("invalid format for Next field")
+	ErrInvalidNextPage = errors.New("invalid format for Next field")
 )
 
 func (r readResponse) parseNext() ([]GetActivitiesOption, error) {

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,7 @@
 package stream
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -21,7 +22,7 @@ func decodeJSONHook(f, typ reflect.Type, data interface{}) (interface{}, error) 
 		case float64:
 			return durationFromString(fmt.Sprintf("%fs", v))
 		default:
-			return nil, fmt.Errorf("invalid duration")
+			return nil, errors.New("invalid duration")
 		}
 	case reflect.TypeOf(Data{}):
 		switch v := data.(type) {
@@ -36,7 +37,7 @@ func decodeJSONHook(f, typ reflect.Type, data interface{}) (interface{}, error) 
 			}
 			return a, nil
 		default:
-			return nil, fmt.Errorf("invalid data")
+			return nil, errors.New("invalid data")
 		}
 	}
 	return data, nil


### PR DESCRIPTION
This change updates how errors are created. When looking through source code I noticed a few things:

* `fmt.Errorf` was used in situations where the error strings had no formatting directives
* When `fmt.Errorf` was used to wrap an error, the `%s` directive was being used

This modifies the source to use `errors.New` when not explicitly formatting an error, I didn't change usage in tests, just in client code. 

It also modifies calls for `fmt.Errorf` to use the `%w` directive to wrap errors instead of `%s`, this way clients can take advantage of [go 1.13 error wrapping](https://blog.golang.org/go1.13-errors)