### PR TITLE
Bump go and lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goVer: [1.12, 1.13]
+        goVer: [1.13, 1.14]
     steps:
       - name: Set up Go ${{ matrix.goVer }}
         uses: actions/setup-go@v1

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 
 # coverage
 coverage.txt
+
+.vscode/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,8 +18,9 @@ linters:
     - govet
     - ineffassign
     - misspell
-    - unconvert
     - staticcheck
+    - unconvert
+    - unused
     - varcheck
 
 linters-settings:

--- a/authenticator.go
+++ b/authenticator.go
@@ -3,7 +3,6 @@ package stream
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	jwt "gopkg.in/dgrijalva/jwt-go.v3"
 )
@@ -148,11 +147,4 @@ func (a authenticator) jwtSignRequest(req *http.Request, claims jwt.MapClaims) e
 	req.Header.Add("Stream-Auth-Type", "jwt")
 	req.Header.Add("Authorization", auth)
 	return nil
-}
-
-func (a authenticator) urlSafe(src string) string {
-	src = strings.ReplaceAll(src, "+", "-")
-	src = strings.ReplaceAll(src, "/", "_")
-	src = strings.Trim(src, "=")
-	return src
 }

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,4 @@ require (
 	gopkg.in/dgrijalva/jwt-go.v3 v3.2.0
 )
 
-go 1.12
+go 1.13

--- a/run-lint.sh
+++ b/run-lint.sh
@@ -9,7 +9,7 @@ gopath="$(go env GOPATH)"
 if ! [[ -x "$gopath/bin/golangci-lint" ]]; then
 	echo >&2 'Installing golangci-lint'
 	curl --silent --fail --location \
-		https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$gopath/bin" v1.22.2
+		https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$gopath/bin" v1.23.6
 fi
 
 # configured by .golangci.yml


### PR DESCRIPTION
* Drop go1.12 and support go1.14
* Bump golangci-lint to the latest and add unused linter
* Drop unused / unexported code
* Add vscode to gitignore