### PR TITLE
Close response body correctly

### DIFF
--- a/client.go
+++ b/client.go
@@ -429,10 +429,10 @@ func (c *Client) request(method string, endpoint endpoint, data interface{}, aut
 	if err != nil {
 		return nil, fmt.Errorf("cannot perform request: %w", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode/100 != 2 {
 		return nil, c.makeStreamError(resp.StatusCode, resp.Body)
 	}
-	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
Otherwise, >299 status code, body isn't closed.