### PR TITLE
Expose rate limit headers in responses

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -11,20 +11,18 @@ type AnalyticsClient struct {
 }
 
 // TrackEngagement is used to send and track analytics EngagementEvents.
-func (c *AnalyticsClient) TrackEngagement(events ...EngagementEvent) error {
+func (c *AnalyticsClient) TrackEngagement(events ...EngagementEvent) (*BaseResponse, error) {
 	endpoint := c.client.makeEndpoint("engagement/")
 	data := map[string]interface{}{
 		"content_list": events,
 	}
-	_, err := c.client.post(endpoint, data, c.client.authenticator.analyticsAuth)
-	return err
+	return decode(c.client.post(endpoint, data, c.client.authenticator.analyticsAuth))
 }
 
 // TrackImpression is used to send and track analytics ImpressionEvents.
-func (c *AnalyticsClient) TrackImpression(eventsData ImpressionEventsData) error {
+func (c *AnalyticsClient) TrackImpression(eventsData ImpressionEventsData) (*BaseResponse, error) {
 	endpoint := c.client.makeEndpoint("impression/")
-	_, err := c.client.post(endpoint, eventsData, c.client.authenticator.analyticsAuth)
-	return err
+	return decode(c.client.post(endpoint, eventsData, c.client.authenticator.analyticsAuth))
 }
 
 // RedirectAndTrack is used to send and track analytics ImpressionEvents. It tracks

--- a/analytics_test.go
+++ b/analytics_test.go
@@ -33,7 +33,7 @@ func TestAnalyticsTrackEngagement(t *testing.T) {
 			stream.NewEventFeature("size", "xxl"),
 		)
 
-	err := analytics.TrackEngagement(event1, event2)
+	_, err := analytics.TrackEngagement(event1, event2)
 	require.NoError(t, err)
 	expectedURL := "https://analytics.stream-io-api.com/analytics/v1.0/engagement/?api_key=key"
 	expectedBody := `{"content_list":[{"boost":10,"content":"abcdef","feed_id":"timeline:123","label":"click","location":"hawaii","position":42,"user_data":{"alias":"John Doe","id":12345}},{"content":"aabbccdd","features":[{"group":"color","value":"red"},{"group":"size","value":"xxl"}],"feed_id":"timeline:123","label":"share","user_data":"bob"}]}`
@@ -54,7 +54,7 @@ func TestAnalyticsTrackImpression(t *testing.T) {
 		WithLocation("hawaii").
 		WithPosition(42)
 
-	err := analytics.TrackImpression(imp)
+	_, err := analytics.TrackImpression(imp)
 	require.NoError(t, err)
 	expectedURL := "https://analytics.stream-io-api.com/analytics/v1.0/impression/?api_key=key"
 	expectedBody := `{"content_list":["a","b","c","d"],"features":[{"group":"color","value":"red"},{"group":"size","value":"xxl"}],"feed_id":"timeline:123","location":"hawaii","position":42,"user_data":123}`

--- a/client_internal_test.go
+++ b/client_internal_test.go
@@ -168,7 +168,7 @@ func Test_makeStreamError(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		err := (&Client{}).makeStreamError(123, tc.body)
+		err := (&Client{}).makeStreamError(123, nil, tc.body)
 		assert.Equal(t, tc.expected.Error(), err.Error())
 		if tc.apiErr.Code != 0 {
 			assert.Equal(t, tc.apiErr, err)

--- a/collections_test.go
+++ b/collections_test.go
@@ -62,7 +62,7 @@ func TestUpsertCollectionObjects(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		err := client.Collections().Upsert(tc.collection, tc.objects...)
+		_, err := client.Collections().Upsert(tc.collection, tc.objects...)
 		require.NoError(t, err)
 		testRequest(t, requester.req, http.MethodPost, tc.expectedURL, tc.expectedBody)
 	}
@@ -113,7 +113,7 @@ func TestDeleteManyCollectionObjects(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		err := client.Collections().DeleteMany(tc.collection, tc.ids...)
+		_, err := client.Collections().DeleteMany(tc.collection, tc.ids...)
 		require.NoError(t, err)
 		testRequest(t, requester.req, http.MethodDelete, tc.expectedURL, "")
 	}
@@ -130,7 +130,7 @@ func TestGetCollectionObject(t *testing.T) {
 func TestDeleteCollectionObject(t *testing.T) {
 	client, requester := newClient(t)
 
-	err := client.Collections().Delete("test-get-one", "id1")
+	_, err := client.Collections().Delete("test-get-one", "id1")
 	require.NoError(t, err)
 	testRequest(t, requester.req, http.MethodDelete, "https://api.stream-io-api.com/api/v1.0/collections/test-get-one/id1/?api_key=key", "")
 }

--- a/errors.go
+++ b/errors.go
@@ -9,6 +9,13 @@ var (
 	errInvalidUserID      = errors.New("invalid userID provided")
 )
 
+// Rate limit headers
+const (
+	HeaderRateLimit     = "X-Ratelimit-Limit"
+	HeaderRateRemaining = "X-Ratelimit-Remaining"
+	HeaderRateReset     = "X-Ratelimit-Reset"
+)
+
 // APIError is an error returned by Stream API when the request cannot be
 // performed or errored server side.
 type APIError struct {
@@ -18,6 +25,7 @@ type APIError struct {
 	Exception       string                   `json:"exception,omitempty"`
 	ExceptionFields map[string][]interface{} `json:"exception_fields,omitempty"`
 	StatusCode      int                      `json:"status_code,omitempty"`
+	Rate            *Rate                    `json:"-"`
 }
 
 func (e APIError) Error() string {

--- a/personalization.go
+++ b/personalization.go
@@ -11,6 +11,17 @@ type PersonalizationClient struct {
 	client *Client
 }
 
+func (c *PersonalizationClient) decode(resp []byte, err error) (*PersonalizationResponse, error) {
+	if err != nil {
+		return nil, err
+	}
+	var result PersonalizationResponse
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, fmt.Errorf("cannot unmarshal resp: %w", err)
+	}
+	return &result, nil
+}
+
 // Get obtains a PersonalizationResponse for the given resource and params.
 func (c *PersonalizationClient) Get(resource string, params map[string]interface{}) (*PersonalizationResponse, error) {
 	if resource == "" {
@@ -20,22 +31,13 @@ func (c *PersonalizationClient) Get(resource string, params map[string]interface
 	for k, v := range params {
 		endpoint.addQueryParam(makeRequestOption(k, v))
 	}
-	resp, err := c.client.get(endpoint, nil, c.client.authenticator.personalizationAuth)
-	if err != nil {
-		return nil, err
-	}
-	var personalizationResp PersonalizationResponse
-	err = json.Unmarshal(resp, &personalizationResp)
-	if err != nil {
-		return nil, fmt.Errorf("cannot unmarshal resp: %w", err)
-	}
-	return &personalizationResp, nil
+	return c.decode(c.client.get(endpoint, nil, c.client.authenticator.personalizationAuth))
 }
 
 // Post sends data to the given resource, adding the given params to the request.
-func (c *PersonalizationClient) Post(resource string, params, data map[string]interface{}) error {
+func (c *PersonalizationClient) Post(resource string, params, data map[string]interface{}) (*PersonalizationResponse, error) {
 	if resource == "" {
-		return errors.New("missing resource")
+		return nil, errors.New("missing resource")
 	}
 	endpoint := c.client.makeEndpoint("%s/", resource)
 	for k, v := range params {
@@ -46,19 +48,17 @@ func (c *PersonalizationClient) Post(resource string, params, data map[string]in
 			"data": data,
 		}
 	}
-	_, err := c.client.post(endpoint, data, c.client.authenticator.personalizationAuth)
-	return err
+	return c.decode(c.client.post(endpoint, data, c.client.authenticator.personalizationAuth))
 }
 
 // Delete removes data from the given resource, adding the given params to the request.
-func (c *PersonalizationClient) Delete(resource string, params map[string]interface{}) error {
+func (c *PersonalizationClient) Delete(resource string, params map[string]interface{}) (*PersonalizationResponse, error) {
 	if resource == "" {
-		return errors.New("missing resource")
+		return nil, errors.New("missing resource")
 	}
 	endpoint := c.client.makeEndpoint("%s/", resource)
 	for k, v := range params {
 		endpoint.addQueryParam(makeRequestOption(k, v))
 	}
-	_, err := c.client.delete(endpoint, nil, c.client.authenticator.personalizationAuth)
-	return err
+	return c.decode(c.client.delete(endpoint, nil, c.client.authenticator.personalizationAuth))
 }

--- a/personalization_test.go
+++ b/personalization_test.go
@@ -23,10 +23,10 @@ func TestPersonalizationPost(t *testing.T) {
 	client, requester := newClient(t)
 	p := client.Personalization()
 	params := map[string]interface{}{"answer": 42, "feed": "user:123"}
-	err := p.Post("", params, nil)
+	_, err := p.Post("", params, nil)
 	require.Error(t, err)
 	data := map[string]interface{}{"foo": "bar", "baz": 42}
-	err = p.Post("some_resource", params, data)
+	_, err = p.Post("some_resource", params, data)
 	require.NoError(t, err)
 	expectedURL := "https://personalization.stream-io-api.com/personalization/v1.0/some_resource/?answer=42&api_key=key&feed=user%3A123"
 	expectedBody := `{"data":{"baz":42,"foo":"bar"}}`
@@ -37,9 +37,9 @@ func TestPersonalizationDelete(t *testing.T) {
 	client, requester := newClient(t)
 	p := client.Personalization()
 	params := map[string]interface{}{"answer": 42, "feed": "user:123"}
-	err := p.Delete("", params)
+	_, err := p.Delete("", params)
 	require.Error(t, err)
-	err = p.Delete("some_resource", params)
+	_, err = p.Delete("some_resource", params)
 	require.NoError(t, err)
 	expectedURL := "https://personalization.stream-io-api.com/personalization/v1.0/some_resource/?answer=42&api_key=key&feed=user%3A123"
 	testRequest(t, requester.req, http.MethodDelete, expectedURL, "")

--- a/reactions_test.go
+++ b/reactions_test.go
@@ -18,7 +18,7 @@ func TestGetReaction(t *testing.T) {
 
 func TestDeleteReaction(t *testing.T) {
 	client, requester := newClient(t)
-	err := client.Reactions().Delete("id1")
+	_, err := client.Reactions().Delete("id1")
 	require.NoError(t, err)
 	testRequest(t, requester.req, http.MethodDelete, "https://api.stream-io-api.com/api/v1.0/reaction/id1/?api_key=key", "")
 }

--- a/users.go
+++ b/users.go
@@ -10,67 +10,47 @@ type UsersClient struct {
 	client *Client
 }
 
+func (c *UsersClient) decode(resp []byte, err error) (*UserResponse, error) {
+	if err != nil {
+		return nil, err
+	}
+	var result UserResponse
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // Add adds a new user with the specified id and optional extra data.
-func (c *UsersClient) Add(user User, getOrCreate bool) (*User, error) {
+func (c *UsersClient) Add(user User, getOrCreate bool) (*UserResponse, error) {
 	endpoint := c.client.makeEndpoint("user/")
 	endpoint.addQueryParam(makeRequestOption("get_or_create", getOrCreate))
 
-	resp, err := c.client.post(endpoint, user, c.client.authenticator.usersAuth)
-	if err != nil {
-		return nil, err
-	}
-
-	result := &User{}
-	err = json.Unmarshal(resp, result)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
+	return c.decode(c.client.post(endpoint, user, c.client.authenticator.usersAuth))
 }
 
 // Update updates the user's data.
-func (c *UsersClient) Update(id string, data map[string]interface{}) (*User, error) {
+func (c *UsersClient) Update(id string, data map[string]interface{}) (*UserResponse, error) {
 	endpoint := c.client.makeEndpoint("user/%s/", id)
 
 	reqData := map[string]interface{}{
 		"data": data,
 	}
-	resp, err := c.client.put(endpoint, reqData, c.client.authenticator.usersAuth)
-	if err != nil {
-		return nil, err
-	}
-
-	result := &User{}
-	err = json.Unmarshal(resp, result)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
+	return c.decode(c.client.put(endpoint, reqData, c.client.authenticator.usersAuth))
 }
 
 // Get retrieves a user having the given id.
-func (c *UsersClient) Get(id string) (*User, error) {
+func (c *UsersClient) Get(id string) (*UserResponse, error) {
 	endpoint := c.client.makeEndpoint("user/%s/", id)
 
-	resp, err := c.client.get(endpoint, nil, c.client.authenticator.usersAuth)
-	if err != nil {
-		return nil, err
-	}
-
-	result := &User{}
-	err = json.Unmarshal(resp, result)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
+	return c.decode(c.client.get(endpoint, nil, c.client.authenticator.usersAuth))
 }
 
 // Delete deletes a user having the given id.
-func (c *UsersClient) Delete(id string) error {
+func (c *UsersClient) Delete(id string) (*BaseResponse, error) {
 	endpoint := c.client.makeEndpoint("user/%s/", id)
 
-	_, err := c.client.delete(endpoint, nil, c.client.authenticator.usersAuth)
-	return err
+	return decode(c.client.delete(endpoint, nil, c.client.authenticator.usersAuth))
 }
 
 // CreateReference returns a new reference string in the form SU:<id>.

--- a/users_test.go
+++ b/users_test.go
@@ -27,7 +27,7 @@ func TestGetUser(t *testing.T) {
 func TestDeleteUser(t *testing.T) {
 	client, requester := newClient(t)
 
-	err := client.Users().Delete("id1")
+	_, err := client.Users().Delete("id1")
 	require.NoError(t, err)
 	testRequest(t, requester.req, http.MethodDelete, "https://api.stream-io-api.com/api/v1.0/user/id1/?api_key=key", "")
 }

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,7 @@
 package stream
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -75,4 +76,15 @@ func parseIntValue(values url.Values, key string) (val int, exits bool, err erro
 func parseBool(value string) bool {
 	v := strings.ToLower(value)
 	return v != "" && v != "false" && v != "f" && v != "0"
+}
+
+func decode(resp []byte, err error) (*BaseResponse, error) {
+	if err != nil {
+		return nil, err
+	}
+	var result BaseResponse
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }


### PR DESCRIPTION
Or on error unless status code is success.

Rate limit is added to personalization but
actually server doesn't serve it so it will be empty.
Missing read support will be addressed in #71 and 
then it will be used.

Fixes #59