### PR TITLE
Reduce nesting for user convenience

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -42,11 +42,14 @@ func (c *CollectionsClient) Select(collection string, ids ...string) (*GetCollec
 	if err != nil {
 		return nil, err
 	}
-	var result GetCollectionResponse
+	var result getCollectionResponseWrap
 	if err := json.Unmarshal(resp, &result); err != nil {
 		return nil, err
 	}
-	return &result, nil
+	return &GetCollectionResponse{
+		response: result.response,
+		Objects:  result.Response.Data,
+	}, nil
 }
 
 // DeleteMany removes from a collection the objects having the given IDs.

--- a/types.go
+++ b/types.go
@@ -464,6 +464,8 @@ type getCollectionResponseWrap struct {
 	Response getCollectionResponse `json:"response"`
 }
 
+// GetCollectionResponse represents a single response coming from a Collection Select
+// request after CollectionsClient.Select call.
 type GetCollectionResponse struct {
 	response
 	Objects []GetCollectionResponseObject

--- a/types.go
+++ b/types.go
@@ -459,9 +459,14 @@ type getCollectionResponse struct {
 	Data []GetCollectionResponseObject `json:"data"`
 }
 
-type GetCollectionResponse struct {
+type getCollectionResponseWrap struct {
 	response
 	Response getCollectionResponse `json:"response"`
+}
+
+type GetCollectionResponse struct {
+	response
+	Objects []GetCollectionResponseObject
 }
 
 // User represents a user


### PR DESCRIPTION
Due to server response structure, there is nesting in the type but it makes common sense longer so hide it.