### PR TITLE
Use json compare to handle syntactic differences in tests

### DIFF
--- a/utils_test.go
+++ b/utils_test.go
@@ -51,7 +51,7 @@ func testRequest(t *testing.T, req *http.Request, method, url, body string) {
 	if req.Method == http.MethodPost {
 		reqBody, err := ioutil.ReadAll(req.Body)
 		require.NoError(t, err)
-		assert.Equal(t, body, string(reqBody))
+		assert.JSONEq(t, body, string(reqBody))
 	}
 	headers := req.Header
 	if headers.Get("X-API-Key") == "" {


### PR DESCRIPTION
Using byte compare for json in tests is error prone for 
* field order change
* whitespace
etc.

instead use json equal to make it more robust to changes.

Side benefit, it can generate better diffs unless equal.