### PR TITLE
Add extra data for target feeds

### DIFF
--- a/reactions_test.go
+++ b/reactions_test.go
@@ -53,6 +53,23 @@ func TestAddReaction(t *testing.T) {
 			expectedURL:  "https://api.stream-io-api.com/api/v1.0/reaction/?api_key=key",
 			expectedBody: `{"kind":"like","activity_id":"some-act-id","user_id":"user-id","target_feeds":["user:bob"]}`,
 		},
+		{
+			input: stream.AddReactionRequestObject{
+				Kind:                 "like",
+				ActivityID:           "some-act-id",
+				UserID:               "user-id",
+				Data:                 map[string]interface{}{"some_extra": "on reaction"},
+				TargetFeeds:          []string{"user:bob"},
+				TargetFeedsExtraData: map[string]interface{}{"some_extra": "on activity"},
+			},
+			expectedURL: "https://api.stream-io-api.com/api/v1.0/reaction/?api_key=key",
+			expectedBody: `{
+				"kind":"like","activity_id":"some-act-id","user_id":"user-id",
+				"data":{"some_extra":"on reaction"},
+				"target_feeds":["user:bob"],
+				"target_feeds_extra_data":{"some_extra":"on activity"}
+			}`,
+		},
 	}
 	for _, tc := range testCases {
 		_, err := client.Reactions().Add(tc.input)
@@ -71,9 +88,17 @@ func TestAddChildReaction(t *testing.T) {
 		Data: map[string]interface{}{
 			"field": "value",
 		},
+		TargetFeeds: []string{"stalker:timeline"},
+		TargetFeedsExtraData: map[string]interface{}{
+			"activity_field": "activity_value",
+		},
 	}
 	expectedURL := "https://api.stream-io-api.com/api/v1.0/reaction/?api_key=key"
-	expectedBody := `{"kind":"like","activity_id":"some-act-id","user_id":"user-id","data":{"field":"value"},"parent":"pid"}`
+	expectedBody := `{
+		"kind":"like","activity_id":"some-act-id","user_id":"user-id",
+		"data":{"field":"value"},"parent":"pid",
+		"target_feeds": ["stalker:timeline"],"target_feeds_extra_data":{"activity_field":"activity_value"}
+	}`
 
 	_, err := client.Reactions().AddChild("pid", reaction)
 	require.NoError(t, err)

--- a/types.go
+++ b/types.go
@@ -497,13 +497,14 @@ type ReactionResponse struct {
 
 // AddReactionRequestObject is an object used only when calling the Add* reaction endpoints
 type AddReactionRequestObject struct {
-	ID          string                 `json:"id,omitempty"`
-	Kind        string                 `json:"kind"`
-	ActivityID  string                 `json:"activity_id"`
-	UserID      string                 `json:"user_id"`
-	Data        map[string]interface{} `json:"data,omitempty"`
-	TargetFeeds []string               `json:"target_feeds,omitempty"`
-	ParentID    string                 `json:"parent,omitempty"`
+	ID                   string                 `json:"id,omitempty"`
+	Kind                 string                 `json:"kind"`
+	ActivityID           string                 `json:"activity_id"`
+	UserID               string                 `json:"user_id"`
+	Data                 map[string]interface{} `json:"data,omitempty"`
+	TargetFeeds          []string               `json:"target_feeds,omitempty"`
+	TargetFeedsExtraData map[string]interface{} `json:"target_feeds_extra_data,omitempty"`
+	ParentID             string                 `json:"parent,omitempty"`
 }
 
 // filterResponse is the part of StreamAPI responses common for FilterReactions API requests.


### PR DESCRIPTION
While a reaction is being added, it can generate activities on `target_feeds`.
Normally, client can pass extra data to be put into these activities. This support is added.