### PR TITLE
Small general improvements

### DIFF
--- a/client.go
+++ b/client.go
@@ -149,9 +149,9 @@ func (c *Client) NotificationFeed(slug, userID string) (*NotificationFeed, error
 
 // GenericFeed returns a standard Feed implementation using the provided target id.
 func (c *Client) GenericFeed(targetID string) (Feed, error) {
-	parts := strings.Split(targetID, ":")
+	parts := strings.Split(targetID, feedSlugIDSeperator)
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid target id: %s", targetID)
+		return nil, fmt.Errorf("invalid target id: %q", targetID)
 	}
 
 	return newFeed(parts[0], parts[1], c)

--- a/feed.go
+++ b/feed.go
@@ -26,9 +26,9 @@ type Feed interface {
 	RealtimeToken(bool) string
 }
 
-var (
-	userIDRegex *regexp.Regexp
-)
+const feedSlugIDSeperator = ":"
+
+var userIDRegex *regexp.Regexp
 
 func init() {
 	userIDRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
@@ -42,7 +42,7 @@ type feed struct {
 
 // ID returns the feed ID, as slug:user_id.
 func (f *feed) ID() string {
-	return fmt.Sprintf("%s:%s", f.slug, f.userID)
+	return fmt.Sprintf("%s%s%s", f.slug, feedSlugIDSeperator, f.userID)
 }
 
 // Slug returns the feed's slug.
@@ -56,7 +56,7 @@ func (f *feed) UserID() string {
 }
 
 func newFeed(slug, userID string, client *Client) (*feed, error) {
-	ok := userIDRegex.Match([]byte(userID))
+	ok := userIDRegex.MatchString(userID)
 	if !ok {
 		return nil, errInvalidUserID
 	}

--- a/run-lint.sh
+++ b/run-lint.sh
@@ -9,7 +9,7 @@ gopath="$(go env GOPATH)"
 if ! [[ -x "$gopath/bin/golangci-lint" ]]; then
 	echo >&2 'Installing golangci-lint'
 	curl --silent --fail --location \
-		https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$gopath/bin" v1.25.0
+		https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$gopath/bin" v1.27.0
 fi
 
 # configured by .golangci.yml


### PR DESCRIPTION
Make feed slug-id separator a constant.

Use match string for regex while checking feed id,
instead of copying.

Bump lint tool.