### PR TITLE
Handle activity references in enrichment

### DIFF
--- a/enriched_activities.go
+++ b/enriched_activities.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -68,6 +69,17 @@ func (a *EnrichedActivity) UnmarshalJSON(b []byte) error {
 			}
 		}
 		data["to"] = simpleTos
+	}
+
+	if v, ok := data["foreign_id"]; ok { // handle activity reference in foreign id
+		if val, ok := v.(map[string]interface{}); ok {
+			id, ok := val["id"].(string)
+			if !ok {
+				return fmt.Errorf("invalid format for enriched referenced activity id: %v", val["id"])
+			}
+			data["foreign_id_ref"] = data["foreign_id"]
+			data["foreign_id"] = "SA:" + id
+		}
 	}
 
 	return a.decode(data)

--- a/enriched_activities_test.go
+++ b/enriched_activities_test.go
@@ -37,6 +37,18 @@ func TestEnrichedActivityUnmarshalJSON(t *testing.T) {
 			activity: stream.EnrichedActivity{To: []string{"abcd", "efgh"}},
 			data:     []byte(`{"to":["abcd","efgh"]}`),
 		},
+		{
+			activity: stream.EnrichedActivity{
+				ForeignID: "SA:123",
+				Extra: map[string]interface{}{
+					"foreign_id_ref": map[string]interface{}{
+						"id":         "123",
+						"extra_prop": true,
+					},
+				},
+			},
+			data: []byte(`{"foreign_id":{"id":"123","extra_prop":true}}`),
+		},
 	}
 	for _, tc := range testCases {
 		var out stream.EnrichedActivity


### PR DESCRIPTION
Referenced activity in `foreign_id` if enriched would be an object. 
Enriched object is unmarshaled to `foreign_id_ref` in `Extra` and id is extracted to `ForeignID` in activity.
Data can't break SDK.